### PR TITLE
Remove proxy env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # bos-v1
 Bos v1 – AI butler web app.
+
+## Networking
+
+The application performs outbound HTTP requests to several APIs. Some
+environments set `HTTP_PROXY`/`HTTPS_PROXY` variables that point to an
+unreachable proxy, which prevents network access. The app now removes these
+variables at startup so it can connect directly.

--- a/app.py
+++ b/app.py
@@ -7,7 +7,12 @@ from speech import speak_text
 from search import intelligent_search
 from dotenv import load_dotenv
 
+
 load_dotenv()  # make sure your .env is loaded
+
+# Disable proxy environment variables that may block outbound HTTP requests
+for var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]:
+    os.environ.pop(var, None)
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.getenv('FLASK_SECRET_KEY')


### PR DESCRIPTION
## Summary
- remove proxy variables at startup so the app can reach external APIs
- document the network fix in the README

## Testing
- `python -m py_compile app.py memory.py search.py speech.py`
