### PR TITLE
Remove DOMContentLoaded wrapper for boot transition

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -163,17 +163,15 @@
 
   <script>
     // BOOT → MAIN
-    window.addEventListener('DOMContentLoaded', () => {
-      const boot = document.getElementById('boot-screen');
-      const main = document.getElementById('main-content');
-      setTimeout(() => {
-        boot.classList.add('fade-out');
-        boot.addEventListener('transitionend', () => {
-          boot.style.display = 'none';
-          main.classList.add('fade-in');
-        }, { once: true });
-      }, 3000);
-    });
+    const boot = document.getElementById('boot-screen');
+    const main = document.getElementById('main-content');
+    setTimeout(() => {
+      boot.classList.add('fade-out');
+      boot.addEventListener('transitionend', () => {
+        boot.style.display = 'none';
+        main.classList.add('fade-in');
+      }, { once: true });
+    }, 3000);
 
     // CHAT & TTS
     const chatLog = document.getElementById('chat-log');


### PR DESCRIPTION
## Summary
- simplify startup code by removing the `DOMContentLoaded` wrapper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
