### PR TITLE
Filter dot-only transcripts

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -186,6 +186,12 @@
     async function sendMessage(txt) {
       let text = typeof txt === 'string' ? txt.trim() : input.value.trim();
       if (!text) return;
+      const cleaned = text.replace(/\s+/g, "");
+      if (/^\.*$/.test(cleaned)) {
+        console.log('Ignoring dot-only input');
+        input.value = '';
+        return;
+      }
       chatLog.innerHTML += `<div class="you"><strong>You:</strong> ${text}</div>`;
       chatLog.scrollTop = chatLog.scrollHeight;
       input.value = '';


### PR DESCRIPTION
## Summary
- ignore partial transcripts that are just dots on the client side

## Testing
- `python -m py_compile app.py memory.py search.py speech.py`