### PR TITLE
Fix requirements spacing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,3 @@ requests==2.31.0
 google-api-python-client>=2.0.0
 google-auth-oauthlib
 google-auth-httplib2
-
-
-
-
-


### PR DESCRIPTION
## Summary
- trim blank lines in `requirements.txt`

## Testing
- `perl -e 'open my $f, "<", "requirements.txt"; seek($f, -1, 2); read($f, $c, 1); print ord($c),"\n";'`