### PR TITLE
Skip Google Sheets logging when creds missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ variables at startup so it can connect directly.
 Set the `GOOGLE_SHEETS_CREDS` environment variable to the path of your
 service account JSON credentials file. When configured, all user and assistant
 messages are appended to the `HECTOR_Memory_Log` Google Sheet for reference.
+If this variable is not set or the credentials file is missing, the app simply
+skips remote logging so `/api/message` continues to function normally.
 
 ## Gmail OAuth
 

--- a/memory.py
+++ b/memory.py
@@ -3,29 +3,54 @@ import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 from datetime import datetime
 
+_scope = [
+    "https://spreadsheets.google.com/feeds",
+    "https://www.googleapis.com/auth/drive",
+]
+
+
+def _get_sheet():
+    """Return the Google Sheet handle or ``None`` if unavailable."""
+    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
+    if not creds_path or not os.path.exists(creds_path):
+        return None
+    try:
+        creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, _scope)
+        client = gspread.authorize(creds)
+        return client.open("HECTOR_Memory_Log").sheet1
+    except Exception as e:
+        print(f"[memory] Google Sheets logging disabled: {e}")
+        return None
+
 def log_message(role, text):
     """Append a timestamped message (role + text) to Google Sheet."""
-    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
-    scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
-    client = gspread.authorize(creds)
-    sheet = client.open("HECTOR_Memory_Log").sheet1
-    sheet.append_row([role, text, datetime.now().isoformat()])
+    sheet = _get_sheet()
+    if not sheet:
+        # Fallback: just print locally so conversations still work
+        print(f"[memory] {role}: {text}")
+        return
+    try:
+        sheet.append_row([role, text, datetime.now().isoformat()])
+    except Exception as e:
+        # Swallow errors so the caller isn't impacted
+        print(f"[memory] Failed to log message: {e}")
+
 def load_memory(limit=20):
     """Fetch the last `limit` messages from the sheet as a list of {role,content}."""
-    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
-    scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
-    client = gspread.authorize(creds)
-    sheet = client.open("HECTOR_Memory_Log").sheet1
-
-    # Get all rows, keep only the last `limit`
-    all_rows = sheet.get_all_values()  # each row = [role, text, timestamp]
-    recent = all_rows[-limit:]
+    sheet = _get_sheet()
+    if not sheet:
+        return []
+    try:
+        # Get all rows, keep only the last `limit`
+        all_rows = sheet.get_all_values()  # each row = [role, text, timestamp]
+        recent = all_rows[-limit:]
+    except Exception as e:
+        print(f"[memory] Failed to load memory: {e}")
+        return []
 
     messages = []
     for row in recent:
-        role, text, _ = row
+        role, text, *_ = row
         messages.append({"role": role, "content": text})
     return messages
 


### PR DESCRIPTION
## Summary
- avoid crashes when `GOOGLE_SHEETS_CREDS` is unset or missing
- fallback to console logging and keep `/api/message` working
- document optional logging behaviour in README

## Testing
- `python -m py_compile app.py memory.py search.py speech.py`
