### PR TITLE
Add running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ messages are appended to the `HECTOR_Memory_Log` Google Sheet for reference.
 Set the `GOOGLE_OAUTH_CLIENT_SECRETS` environment variable to the path of your
 Google OAuth client secrets JSON. The application defaults to `credentials.json`
 in the repository root if this variable is not provided.
+
+## Running the app
+
+Install Python dependencies and launch the server locally:
+
+```bash
+pip install -r requirements.txt
+python3 app.py
+```
+
+The server listens on port `5001` by default. Set the `PORT` environment
+variable to change the port, for example if `5001` is already in use:
+
+```bash
+PORT=5050 python3 app.py
+```


### PR DESCRIPTION
## Summary
- document how to start the web app
- include pip install instructions and PORT environment variable usage

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
