### PR TITLE
Change default port to 5002

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ pip install -r requirements.txt
 python3 app.py
 ```
 
-The server listens on port `5001` by default. Set the `PORT` environment
-variable to change the port, for example if `5001` is already in use:
+The server listens on port `5002` by default. Set the `PORT` environment
+variable to change the port, for example if `5002` is already in use:
 
 ```bash
 PORT=5050 python3 app.py

--- a/app.py
+++ b/app.py
@@ -310,5 +310,5 @@ def web_search():
 
 
 if __name__ == "__main__":
-    port = int(os.getenv("PORT", 5001))
+    port = int(os.getenv("PORT", 5002))
     app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
## Summary
- update `app.py` to use `PORT` env variable defaulting to `5002`
- document that the server listens on port `5002` by default

## Testing
- `python3 -m py_compile app.py memory.py search.py speech.py`