### PR TITLE
Fix instructions for OAuth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ pip install -r requirements.txt
 python3 app.py
 ```
 
+If you skip the `pip install` step, the server fails to start with errors like
+`ModuleNotFoundError: No module named 'openai'`, which means `/oauth2login` will
+refuse to connect because nothing is listening on port 5002.
+
 The server listens on port `5002` by default. Set the `PORT` environment
 variable to change the port, for example if `5002` is already in use:
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,12 @@
 
 import os
 import json
-import openai
+try:
+    import openai
+except ImportError as e:
+    raise ImportError(
+        "Missing required package 'openai'. Run 'pip install -r requirements.txt' first."
+    ) from e
 from flask import Flask, render_template, request, jsonify
 from speech import speak_text
 from search import intelligent_search


### PR DESCRIPTION
## Notes
- add helpful message if `openai` package is missing
- README now points out that skipping `pip install` will cause `/oauth2login` to refuse connection

## Testing
- `python3 -m py_compile app.py`