### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,3 @@ variable to change the port, for example if `5002` is already in use:
 ```bash
 PORT=5050 python3 app.py
 ```
- main


### PR DESCRIPTION
## Summary
- remove stray `main` line at the end of README

## Testing
- `pytest -q` *(fails: command not found)*