### PR TITLE
Store Gmail OAuth tokens server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ account. Follow these steps:
 3. Set the `GOOGLE_OAUTH_CLIENT_SECRETS` environment variable to the path of this
    JSON file. If the variable is not set, the app looks for `credentials.json` in
    the repository root.
-4. Run the server and visit `/oauth2login` in your browser to authorize the
+4. (Optional) Set `GMAIL_TOKEN_FILE` to control where the OAuth token is stored.
+   It defaults to `gmail_token.json` in the repository root.
+5. Run the server and visit `/oauth2login` in your browser to authorize the
    application. Once authorization completes you can use `/api/email/send` to
    dispatch messages on behalf of the authenticated account.
    
 Set the `GOOGLE_OAUTH_CLIENT_SECRETS` environment variable to the path of your
 Google OAuth client secrets JSON. The application defaults to `credentials.json`
-in the repository root if this variable is not provided.
+in the repository root if this variable is not provided. The OAuth token is
+saved to `gmail_token.json` unless you override the path with
+`GMAIL_TOKEN_FILE`.
 
 ## Running the app
 


### PR DESCRIPTION
## Summary
- persist Gmail tokens to a server-side file instead of the browser session
- load and refresh tokens from that file
- document `GMAIL_TOKEN_FILE` in Gmail OAuth instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`