### PR TITLE
Improve credential error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,6 +77,8 @@ CLIENT_SECRETS_FILE = os.getenv("GOOGLE_OAUTH_CLIENT_SECRETS", "credentials.json
 
 @app.route("/oauth2login")
 def oauth2login():
+    if not os.path.exists(CLIENT_SECRETS_FILE):
+        return "Gmail client secrets file not found", 500
     flow = Flow.from_client_secrets_file(
         CLIENT_SECRETS_FILE,
         scopes=SCOPES,

--- a/memory.py
+++ b/memory.py
@@ -3,21 +3,36 @@ import gspread
 from oauth2client.service_account import ServiceAccountCredentials
 from datetime import datetime
 
+
+def _get_sheet():
+    """Return authorized gspread worksheet or None if creds missing."""
+    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
+    if not creds_path:
+        return None, "GOOGLE_SHEETS_CREDS environment variable not set"
+    if not os.path.exists(creds_path):
+        return None, f"Google Sheets credentials file not found: {creds_path}"
+    scope = [
+        "https://spreadsheets.google.com/feeds",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
+    client = gspread.authorize(creds)
+    sheet = client.open("HECTOR_Memory_Log").sheet1
+    return sheet, None
+
 def log_message(role, text):
     """Append a timestamped message (role + text) to Google Sheet."""
-    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
-    scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
-    client = gspread.authorize(creds)
-    sheet = client.open("HECTOR_Memory_Log").sheet1
+    sheet, err = _get_sheet()
+    if err:
+        return err
     sheet.append_row([role, text, datetime.now().isoformat()])
+    return None
+
 def load_memory(limit=20):
     """Fetch the last `limit` messages from the sheet as a list of {role,content}."""
-    creds_path = os.getenv("GOOGLE_SHEETS_CREDS")
-    scope = ['https://spreadsheets.google.com/feeds','https://www.googleapis.com/auth/drive']
-    creds = ServiceAccountCredentials.from_json_keyfile_name(creds_path, scope)
-    client = gspread.authorize(creds)
-    sheet = client.open("HECTOR_Memory_Log").sheet1
+    sheet, err = _get_sheet()
+    if err:
+        return err
 
     # Get all rows, keep only the last `limit`
     all_rows = sheet.get_all_values()  # each row = [role, text, timestamp]


### PR DESCRIPTION
## Summary
- prevent `/oauth2login` from crashing when Gmail client secrets are missing
- gracefully handle missing `GOOGLE_SHEETS_CREDS` in `memory.py`

## Testing
- `python3 -m py_compile app.py memory.py search.py speech.py`