### PR TITLE
Improve conversation memory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ variables at startup so it can connect directly.
 Set the `GOOGLE_SHEETS_CREDS` environment variable to the path of your
 service account JSON credentials file. When configured, all user and assistant
 messages are appended to the `HECTOR_Memory_Log` Google Sheet for reference.
+If the variable is omitted or the file is missing, the application simply
+skips loading and logging conversation history.
 
 ## Gmail OAuth
 

--- a/app.py
+++ b/app.py
@@ -251,12 +251,20 @@ def index():
 def message():
     data      = request.get_json() or {}
     user_text = data.get("text", "").strip()
+
+    # Load previous conversation from Google Sheets (if configured)
+    history = load_memory()
+    if not isinstance(history, list):
+        history = []
+
+    # Build the message list for ChatGPT
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": user_text})
+
+    # Log after loading so we don't duplicate the latest message
     log_message("user", user_text)
 
-    messages = [
-        {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user",   "content": user_text}
-    ]
     resp = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=messages


### PR DESCRIPTION
## Summary
- load chat history from Google Sheets before responding
- gracefully skip Google Sheets access when credentials are absent
- update README to note optional logging

## Testing
- `python3 -m py_compile app.py memory.py search.py speech.py`