### PR TITLE
Remove placeholder line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ messages are appended to the `HECTOR_Memory_Log` Google Sheet for reference.
 
 ## Gmail OAuth
 
-codex/expand-readme-md-for-gmail-oauth-setup
 The application can send and read email once it is authorized with a Google
 account. Follow these steps:
 


### PR DESCRIPTION
## Summary
- remove leftover `codex/expand-readme-md-for-gmail-oauth-setup` line

## Testing
- `pytest -q` *(fails: command not found)*