### PR TITLE
Fix NameError by importing load_memory

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from google.oauth2.credentials   import Credentials
 from googleapiclient.discovery    import build
 from google.auth.transport.requests import Request
 import base64
-from memory import log_message
+from memory import log_message, load_memory
 
 
 


### PR DESCRIPTION
## Summary
- import `load_memory` from `memory` in `app.py`

## Testing
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'openai')*