### PR TITLE
Normalize assistant role in memory and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -294,7 +294,7 @@ def message():
     else:
         reply = raw
 
-    log_message("hector", reply)
+    log_message("assistant", reply)
 
     return jsonify({"reply": reply})
 

--- a/memory.py
+++ b/memory.py
@@ -42,6 +42,9 @@ def load_memory(limit=20):
     messages = []
     for row in recent:
         role, text, _ = row
+        role = role.lower()
+        if role == "hector":
+            role = "assistant"
         messages.append({"role": role, "content": text})
     return messages
 


### PR DESCRIPTION
## Summary
- normalize role names when loading memory so old entries from "hector" become "assistant"
- log assistant replies under the "assistant" role

## Testing
- `python3 -m py_compile app.py memory.py search.py speech.py`
- `python3 app.py` *(fails: `ModuleNotFoundError: No module named 'openai'`)*