### PR TITLE
Update README port instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ If you skip the `pip install` step, the server fails to start with errors like
 `ModuleNotFoundError: No module named 'openai'`, which means `/oauth2login` will
 refuse to connect because nothing is listening on port 5002.
 
-The server listens on port `5002` by default. Set the `PORT` environment
-variable to change the port, for example if `5002` is already in use:
+The server listens on port `5002` by default. Hosting services such as Render
+often set the `PORT` environment variable to something else (sometimes as high
+as `10000`). You can override the port manually when launching the server:
 
 ```bash
-PORT=5050 python3 app.py
+PORT=5001 python3 app.py
 ```


### PR DESCRIPTION
## Summary
- clarify that Flask defaults to port 5002
- mention that hosting services may set `PORT` (e.g. 10000)
- show an example for overriding with `PORT=5001`

## Testing
- `python3 -m py_compile app.py memory.py search.py speech.py`