### PR TITLE
Enforce search API env vars

### DIFF
--- a/app.py
+++ b/app.py
@@ -340,6 +340,11 @@ def message():
         # perform intelligent_search
         try:
             items = intelligent_search(query)
+        except RuntimeError as e:
+            reply = f"Search configuration error: {e}"
+        except Exception as e:
+            reply = f"Search error: {e}"
+        else:
             if not items:
                 reply = f"No results found for “{query}.”"
             else:
@@ -347,8 +352,6 @@ def message():
                 for i, item in enumerate(items, start=1):
                     lines.append(f"{i}. {item['title']}\n   {item['snippet']}\n   {item['link']}")
                 reply = "\n".join(lines)
-        except Exception as e:
-            reply = f"Search error: {e}"
     else:
         reply = raw
 
@@ -377,15 +380,18 @@ def web_search():
 
     try:
         items = intelligent_search(query)
-        results = [
-            {"title": item.get("title"),
-             "snippet": item.get("snippet"),
-             "link": item.get("link")}
-            for item in items
-        ]
-        return jsonify({"results": results})
+    except RuntimeError as e:
+        return jsonify({"error": str(e)}), 500
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+    results = [
+        {"title": item.get("title"),
+         "snippet": item.get("snippet"),
+         "link": item.get("link")}
+        for item in items
+    ]
+    return jsonify({"results": results})
 
 
 if __name__ == "__main__":

--- a/search.py
+++ b/search.py
@@ -4,6 +4,12 @@ from googleapiclient.discovery import build
 def intelligent_search(query, num_results=5):
     api_key = os.getenv("GOOGLE_SEARCH_API_KEY")
     cse_id  = os.getenv("GOOGLE_CSE_ID")
+
+    if not api_key:
+        raise RuntimeError("Missing GOOGLE_SEARCH_API_KEY")
+    if not cse_id:
+        raise RuntimeError("Missing GOOGLE_CSE_ID")
+
     service = build("customsearch", "v1", developerKey=api_key)
     res     = service.cse().list(q=query, cx=cse_id, num=num_results).execute()
     return res.get("items", [])


### PR DESCRIPTION
## Summary
- require `GOOGLE_SEARCH_API_KEY` and `GOOGLE_CSE_ID` in `intelligent_search`
- surface config errors in message and web_search routes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`