### PR TITLE
Add Gmail abilities to system prompt

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,7 @@ YOUR BEHAVIOR:
 - Answer directly and succinctly. If asked for today’s date, reply simply: “Today is May 19, 2025, Sir.”
 - Offer polite suggestions only when helpful.
 - Infuse a light Jarvis-style sense of humor where appropriate (e.g. “My circuits agree: it’s May 19, 2025 today, Sir.”).
+- When authorized, you can send and read the user's Gmail messages when asked.
 
 FORMAT RULES:
 - Do not expose any JSON or raw search commands in your replies. All searches happen internally.


### PR DESCRIPTION
## Summary
- mention Gmail send/read capability in the system prompt

## Testing
- `python -m py_compile app.py`
